### PR TITLE
Run the tests headless by default

### DIFF
--- a/src/main/kotlin/com/jjtparadox/barometer/tester/Tests.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/tester/Tests.kt
@@ -55,7 +55,7 @@ class BarometerTester(klass: Class<*>) : BlockJUnit4ClassRunner(load(klass)) {
                 val thread = Thread.currentThread()
                 val contextClassLoader = thread.contextClassLoader
 
-                GradleStartTestServer().launch(arrayOf("--noCoreSearch"))
+                GradleStartTestServer().launch(arrayOf("--noCoreSearch", "nogui"))
 
                 thread.contextClassLoader = contextClassLoader
 


### PR DESCRIPTION
This change prevents the server gui popping up when you are running tests.
I'm not sure this is 100% necessary but I imagine it could cause problems on CI machines.