### PR TITLE
Update reference to the eula in the notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run all tests with `gradle test`.
 
 ## Notes:
 - All tests are server side ONLY.
-- Remember to agree to `eula.txt` in your test's run dir.
+- Remember to agree to `eula.txt` in your test's run dir.  If you use the gradle test task above, this will be done for you.
 - Use `TestUtils.tickServer();` to tick the server while in tests.
 - Always update the `barometer.numClasses` property in `build.gradle` every time you create or remove a test class.
 - This is very alpha and will probably collapse into a black hole if you sneeze on it. Please report bugs and submit PRs to GitHub!


### PR DESCRIPTION
After reading the README again online after https://github.com/jjtParadox/Barometer/pull/4 was merged I realized that there was a reference to the eula in the notes section that could use an update.
This PR fixes that.