### PR TITLE
Update default settings to make a 'redstone ready' world

### DIFF
--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -88,7 +88,7 @@ class Barometer {
         MinecraftForge.EVENT_BUS.register(this)
     }
 
-    private fun safeSet(settings: PropertyManager, key: String, value: Any){
+    private fun safeSet(settings: PropertyManager, key: String, value: Any) {
         if ( !settings.hasProperty(key) )
             settings.setProperty(key, value)
     }

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -65,10 +65,10 @@ class Barometer {
             throw IllegalStateException("The Barometer mod should only be used in a deobsfucated test environment!")
         }
 
-        //TODO Allow all this stuff to be configured from build.gradle (or some better place?)
         theServer = FMLCommonHandler.instance().minecraftServerInstance as DedicatedServer
         val serverSettings = PropertyManager(File("server.properties"))
 
+        // Use safeSet so as to preserve any existing server.properties file
         safeSet(serverSettings, "online-mode", false)
         safeSet(serverSettings,"server-ip", "127.0.0.1")
         safeSet(serverSettings,"spawn-animals", false)
@@ -92,12 +92,6 @@ class Barometer {
         if ( !settings.hasProperty(key) )
             settings.setProperty(key, value)
     }
-
-//TODO Make a nice empty world for tests
-//    @Mod.EventHandler
-//    fun init(event: FMLInitializationEvent) {
-//        TestWorldType()
-//    }
 
     @Mod.EventHandler
     fun serverAboutToStart(event: FMLServerAboutToStartEvent) {

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -79,7 +79,7 @@ class Barometer {
         safeSet(serverSettings,"generate-structures", false)
         safeSet(serverSettings,"gamemode", 0)
         safeSet(serverSettings,"level-type", "FLAT")
-        safeSet(serverSettings,"generator-settings", "3;minecraft:bedrock,3*minecraft:stone,52*minecraft:sandstone;2;")
+        safeSet(serverSettings,"generator-settings", "3;minecraft:air;127;")
         safeSet(serverSettings,"max-tick-time", 0)
         serverSettings.saveProperties()
 

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -79,6 +79,7 @@ class Barometer {
         serverSettings.setProperty("generate-structures", false)
         serverSettings.setProperty("gamemode", 0)
         serverSettings.setProperty("level-type", "FLAT")
+        serverSettings.setProperty("generator-settings", "3;minecraft:bedrock,3*minecraft:stone,52*minecraft:sandstone;2;")
         serverSettings.setProperty("max-tick-time", 0)
         serverSettings.saveProperties()
 

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -69,23 +69,28 @@ class Barometer {
         theServer = FMLCommonHandler.instance().minecraftServerInstance as DedicatedServer
         val serverSettings = PropertyManager(File("server.properties"))
 
-        serverSettings.setProperty("online-mode", false)
-        serverSettings.setProperty("server-ip", "127.0.0.1")
-        serverSettings.setProperty("spawn-animals", false)
-        serverSettings.setProperty("spawn-npcs", false)
-        serverSettings.setProperty("motd", "Barometer Test Server")
-        serverSettings.setProperty("force-gamemode", true)
-        serverSettings.setProperty("difficulty", 0)
-        serverSettings.setProperty("generate-structures", false)
-        serverSettings.setProperty("gamemode", 0)
-        serverSettings.setProperty("level-type", "FLAT")
-        serverSettings.setProperty("generator-settings", "3;minecraft:bedrock,3*minecraft:stone,52*minecraft:sandstone;2;")
-        serverSettings.setProperty("max-tick-time", 0)
+        safeSet(serverSettings, "online-mode", false)
+        safeSet(serverSettings,"server-ip", "127.0.0.1")
+        safeSet(serverSettings,"spawn-animals", false)
+        safeSet(serverSettings,"spawn-npcs", false)
+        safeSet(serverSettings,"motd", "Barometer Test Server")
+        safeSet(serverSettings,"force-gamemode", true)
+        safeSet(serverSettings,"difficulty", 0)
+        safeSet(serverSettings,"generate-structures", false)
+        safeSet(serverSettings,"gamemode", 0)
+        safeSet(serverSettings,"level-type", "FLAT")
+        safeSet(serverSettings,"generator-settings", "3;minecraft:bedrock,3*minecraft:stone,52*minecraft:sandstone;2;")
+        safeSet(serverSettings,"max-tick-time", 0)
         serverSettings.saveProperties()
 
         server.serverOwner = "barometer_test_player"
 
         MinecraftForge.EVENT_BUS.register(this)
+    }
+
+    private fun safeSet(settings: PropertyManager, key: String, value: Any){
+        if ( !settings.hasProperty(key) )
+            settings.setProperty(key, value)
     }
 
 //TODO Make a nice empty world for tests


### PR DESCRIPTION
This is one way to update the server.properties file as mentioned in this PR: https://github.com/jjtParadox/Barometer/pull/4.

Here I'm taking the approach of adding the setting from the code, as I noticed that other settings were being set that way.

However, I noticed this comment in the code right before the code that adds the settings: `//TODO Allow all this stuff to be configured from build.gradle (or some better place?)`

This prompts me to mention that another way to add the server properties would be in the 'test' task in the build.gradle file.  For example:

```
    file("$workingDir/server.properties").text = """
level-type=FLAT
generator-settings=3;minecraft:bedrock,3*minecraft:stone,52*minecraft:sandstone;2;
online-mode=false
level-name=integrateddynamics.test
"""
```

To support this, I made a change to the hard-coded settings so that they will not overwrite the user's options in this case.  I think it would be convenient for the code to generate good settings by default, but  not overwrite settings that may have already been placed there by build.gradle.

Perhaps I should remove this piece of code now?:

```
//TODO Make a nice empty world for tests
//    @Mod.EventHandler
//    fun init(event: FMLInitializationEvent) {
//        TestWorldType()
//    }
```

Also, should I remove the `//TODO Allow all this stuff to be configured from build.gradle (or some better place?)`, as perhaps this PR addresses that?

FYI: The particular generator-settings string I'm using here is the one used for the 'Redstone Ready' preset that ships with the base game.  I prefer this to just filling everything with air, but your mileage may vary ;)