### PR TITLE
Support for determining the number of Barometer tests to run automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-reflect:1.1.2-5"
     testCompile "junit:junit:4.12"
     testCompile makeStart.outputs.files
+    
+    testRuntime "io.github.lukehutch:fast-classpath-scanner:2.18.1"
 }
 ```
 
 Add the following to the end of `build.gradle`:
 
 ```gradle
-test {
-    // Number of test classes that are run before the server is closed (if this value is wrong things will break!)
-    systemProperty 'barometer.numClasses', 1
-    
+test {    
     workingDir = {minecraft.runDir + "/test"} // This can be set to whatever you prefer
     
     mkdir workingDir // Make sure the directory exists.
@@ -46,5 +45,4 @@ Run all tests with `gradle test`.
 - All tests are server side ONLY.
 - Remember to agree to `eula.txt` in your test's run dir.  If you use the gradle test task above, this will be done for you.
 - Use `TestUtils.tickServer();` to tick the server while in tests.
-- Always update the `barometer.numClasses` property in `build.gradle` every time you create or remove a test class.
 - This is very alpha and will probably collapse into a black hole if you sneeze on it. Please report bugs and submit PRs to GitHub!

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     compile 'junit:junit:4.12'
     compile makeStart.outputs.files
 
+    compile "io.github.lukehutch:fast-classpath-scanner:2.18.1"
+
     testCompile "org.mockito:mockito-core:2.+"
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
@@ -65,9 +67,6 @@ dependencies {
 }
 
 test {
-    // Number of test classes that are run before the server is closed (if this value is wrong things will break!)
-    systemProperty 'barometer.numClasses', 2
-
     workingDir = { minecraft.runDir + "/test" }
 
     mkdir workingDir

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -19,6 +19,8 @@
 package com.jjtparadox.barometer
 
 import com.google.common.collect.Queues
+import com.jjtparadox.barometer.tester.BarometerTester
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner
 import net.minecraft.launchwrapper.Launch
 import net.minecraft.server.dedicated.DedicatedServer
 import net.minecraft.server.dedicated.PropertyManager
@@ -36,6 +38,7 @@ import net.minecraftforge.fml.common.event.FMLServerStoppedEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import org.junit.runner.RunWith
 import java.io.File
 import java.util.Queue
 import java.util.concurrent.CountDownLatch
@@ -55,6 +58,22 @@ class Barometer {
 
         @JvmStatic val server by lazy { theServer } // Hack to create a lateinit val
         private lateinit var theServer: DedicatedServer
+
+        // Use reflection to find the number of Barometer tests being run
+        @JvmStatic
+        fun getTestCount(): Int {
+            var numTests = 0;
+            // Only scan directories for .class files
+            var scanner = FastClasspathScanner("-jar:")
+            scanner.matchClassesWithAnnotation(RunWith::class.java,
+                    { c -> run {
+                        val value = c.getAnnotation(RunWith::class.java).value
+                        if ( value == BarometerTester::class )
+                            numTests++
+                    } })
+            scanner.scan()
+            return numTests
+        }
     }
 
     @Mod.EventHandler

--- a/src/test/kotlin/com/jjtparadox/barometer/otherpackage/test/OtherPackageTest.kt
+++ b/src/test/kotlin/com/jjtparadox/barometer/otherpackage/test/OtherPackageTest.kt
@@ -1,0 +1,15 @@
+package com.jjtparadox.barometer.otherpackage.test
+
+import com.jjtparadox.barometer.tester.BarometerTester
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(BarometerTester::class)
+class BarometerExampleTest {
+
+    @Test
+    fun testThatTestCountingWorksAcrossMultiplePackages() {
+        println("Picked up the test in the other package!")
+    }
+
+}


### PR DESCRIPTION
I've used [fast classpath scanner](https://github.com/lukehutch/fast-classpath-scanner) to remove the need for the 'barometer.numClasses' system property.

The only disadvantage I can see to this is that users have to add fast-classpath-scanner to their testRuntime dependencies, but I think that isn't too onerous.

I've gone ahead and updated the README as well.