### PR TITLE
Move kotlin over to a testRuntime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Add the following to your `build.gradle`'s dependency section:
 ```gradle
 dependencies {
     // ...
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib:1.1.2-5"
-    testCompile "org.jetbrains.kotlin:kotlin-reflect:1.1.2-5"
     testCompile "junit:junit:4.12"
     testCompile makeStart.outputs.files
     
+    testRuntime "org.jetbrains.kotlin:kotlin-stdlib:1.1.2-5"
+    testRuntime "org.jetbrains.kotlin:kotlin-reflect:1.1.2-5"
     testRuntime "io.github.lukehutch:fast-classpath-scanner:2.18.1"
 }
 ```


### PR DESCRIPTION
Alright, one last thing -- an update to the README, as I've found in practice that kotlin is only needed as a testRuntime dependency in the user's mod.

Also, a quick question -- do you want to do an official 0.0.3 release?  I'd like to try adding this to the cyclops maven repo now, and it would be nice to have an offical jar built by the author to put there.
