### PR TITLE
Add client interaction functionality

### DIFF
--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -19,6 +19,7 @@
 package com.jjtparadox.barometer
 
 import com.google.common.collect.Queues
+import com.jjtparadox.barometer.commands.CommandExit
 import net.minecraft.launchwrapper.Launch
 import net.minecraft.server.dedicated.DedicatedServer
 import net.minecraft.server.dedicated.PropertyManager
@@ -51,6 +52,9 @@ class Barometer {
     companion object {
         const val MOD_ID = "barometer"
         const val VERSION = "0.0.3-1.12"
+
+        @Mod.Instance
+        var instance: Barometer? = null
 
         @JvmField val futureTaskQueue: Queue<FutureTask<*>> = Queues.newArrayDeque<FutureTask<*>>()
         @JvmField var testing = true
@@ -100,6 +104,11 @@ class Barometer {
 
     @Mod.EventHandler
     fun serverAboutToStart(event: FMLServerAboutToStartEvent) {
+    }
+
+    @Mod.EventHandler
+    fun serverStarting(event: FMLServerStartingEvent) {
+        event.registerServerCommand(CommandExit())
     }
 
     @Mod.EventHandler

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -43,7 +43,8 @@ import java.util.concurrent.FutureTask
 
 val LOGGER: Logger = LogManager.getLogger(Barometer.MOD_ID)
 
-@Mod(modid = Barometer.MOD_ID, version = Barometer.VERSION, serverSideOnly = true)
+@Mod(modid = Barometer.MOD_ID, version = Barometer.VERSION, serverSideOnly = true,
+        acceptableRemoteVersions = "*")
 class Barometer {
     companion object {
         const val MOD_ID = "barometer"

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -32,7 +32,9 @@ import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 import net.minecraftforge.fml.common.event.FMLServerAboutToStartEvent
 import net.minecraftforge.fml.common.event.FMLServerStartedEvent
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent
+
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -122,10 +124,19 @@ class Barometer {
     // Clear all worlds and shut down the server
     private fun endTesting() {
         if ( shutdownOnEndTesting ) {
-            server.worlds = null
-            server.initiateShutdown()
-        } else
-            println("Tests completed.  Keeping server running... (Use Ctrl-C to stop)")
+            shutdown()
+        } else {
+            // Switch on the dedicated server gui so that it can be easily shut down
+            server.setGuiEnabled()
+            println("Barometer testing complete, but a request has been made to keep the server running")
+            println("Use the 'exit' command (from the Barometer mod) to stop the server without saving")
+            println("Use the 'stop' command (from minecraft) to save and stop the server")
+        }
+    }
+
+    fun shutdown() {
+        server.worlds = null
+        server.initiateShutdown()
     }
 
     // Set world spawn to origin and add a loaded chunk so the world ticks without needing a player

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -102,6 +102,10 @@ class Barometer {
 
     @Mod.EventHandler
     fun serverStarted(event: FMLServerStartedEvent) {
+        // Switch off auto-save
+        val commandManager = server.getCommandManager()
+        commandManager.executeCommand(server, "save-off")
+
         while (testing) {
             synchronized(futureTaskQueue) {
                 futureTaskQueue.forEach { it.run() }

--- a/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/Barometer.kt
@@ -53,6 +53,8 @@ class Barometer {
         @JvmField var testing = true
         @JvmField var finishedLatch = CountDownLatch(1)
 
+        @JvmField var shutdownOnEndTesting = true
+
         @JvmStatic val server by lazy { theServer } // Hack to create a lateinit val
         private lateinit var theServer: DedicatedServer
     }
@@ -114,8 +116,11 @@ class Barometer {
 
     // Clear all worlds and shut down the server
     private fun endTesting() {
-        server.worlds = null
-        server.initiateShutdown()
+        if ( shutdownOnEndTesting ) {
+            server.worlds = null
+            server.initiateShutdown()
+        } else
+            println("Tests completed.  Keeping server running... (Use Ctrl-C to stop)")
     }
 
     // Set world spawn to origin and add a loaded chunk so the world ticks without needing a player

--- a/src/main/kotlin/com/jjtparadox/barometer/TestUtils.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/TestUtils.kt
@@ -23,4 +23,12 @@ object TestUtils {
         //TODO tick the server in a way that doesn't autosave unless requested
         Barometer.server.tick()
     }
+
+    /**
+     * @param shutdownOnEndTesting set to false to keep the server running when testing ends
+     */
+    @JvmStatic fun setShutdownOnEndTesting(shutdownOnEndTesting: Boolean) {
+        Barometer.shutdownOnEndTesting = shutdownOnEndTesting
+    }
+
 }

--- a/src/main/kotlin/com/jjtparadox/barometer/commands/CommandExit.kt
+++ b/src/main/kotlin/com/jjtparadox/barometer/commands/CommandExit.kt
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Barometer
+ *
+ * Copyright (c) 2018 jjtParadox
+ *
+ * Barometer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Barometer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Barometer. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.jjtparadox.barometer.commands
+
+import com.jjtparadox.barometer.Barometer
+import net.minecraft.command.CommandBase
+import net.minecraft.command.ICommandSender
+import net.minecraft.server.MinecraftServer
+
+/**
+ * Command for stopping the server without saving any worlds
+ */
+class CommandExit : CommandBase() {
+
+    override fun getName(): String {
+        return "exit"
+    }
+
+    override fun getUsage(sender: ICommandSender?): String {
+        return "exit"
+    }
+
+    override fun execute(server: MinecraftServer?, sender: ICommandSender?, args: Array<out String>?) {
+        Barometer.instance?.shutdown()
+    }
+
+}


### PR DESCRIPTION
I'm not sure if this is the kind of thing you want to do with this tool, but I find it really useful to be able to keep the test world open when testing is over, and then connect to it with a client and take a look around to see if the world looks the way I expect it should given the tests that I've run.

To this end I've added the following features:

* Added a shutdownOnEndTesting flag so that the server can be kept running when testing ends
    Setting this flag on causes the server gui to be shown so that the user can manually save and/or stop the world
* Switched off world auto save by default so that nothing will ever get saved automatially
* Allow a client that does not have Barometer installed connect to the world
* Added an 'exit' command so that the server can be manually stopped in the same way it is normally stopped after testing -- guaranteeing that nothing gets saved.  The user still has the option to use the regular 'stop' command to save the world on exit.