### PR TITLE
Switch gradle plugin dependencies to provided to fix test runtime errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 
     compile "io.github.lukehutch:fast-classpath-scanner:2.18.1"
 
-    provided gradleApi()
-    provided ("net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT") {
+    compileOnly gradleApi()
+    compileOnly ("net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT") {
         exclude group: "com.google.code"
         exclude group: "com.google.guava"
         exclude group: "commons-codec"

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 
     compile "io.github.lukehutch:fast-classpath-scanner:2.18.1"
 
-    compile gradleApi()
-    compile ("net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT") {
+    provided gradleApi()
+    provided ("net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT") {
         exclude group: "com.google.code"
         exclude group: "com.google.guava"
         exclude group: "commons-codec"


### PR DESCRIPTION
Fixes this issue: https://github.com/jjtParadox/Barometer/issues/11
